### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Math/RungeKutta.pm
+++ b/lib/Math/RungeKutta.pm
@@ -1,4 +1,4 @@
-module Math::RungeKutta;
+unit module Math::RungeKutta;
 
 # the actual integation loop
 sub rk-integrate (


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
